### PR TITLE
Scientific notation, object reuse, documentation, and test cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Support for numbers in scientific notation.
 ### Changed
+- Parser constructor no longer requires a value enabling instance reuse.
+- Lexer constructor no longer requires a value enabling instance reuse.
+- Lexer instance used in Parser now a static var.
+- Tests now use Composer autoload.
+- PHPUnit XML now conformant.
+- Documentation updated with new usage pattern.
+### Removed
+- TestInit no longer needed
 
 ## [2.0.0] - 2015-11-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,15 +4,31 @@
 [![Test Coverage](https://codeclimate.com/github/creof/geo-parser/badges/coverage.svg)](https://codeclimate.com/github/creof/geo-parser/coverage)
 [![Build Status](https://travis-ci.org/creof/geo-parser.svg)](https://travis-ci.org/creof/geo-parser)
 
-Lexer and parser library for geometric and geographic string values.
+Lexer and parser library for geometric and geographic point string values.
 
 ## Usage
-Pass value to be parsed in the constructor, then call parse() on the created object.
+
+There are two use patterns for the parser. The value to be parsed can be passed into the constructor, then parse()
+called on the returned ```Parser``` object:
 
 ```php
 $input  = '79°56′55″W, 40°26′46″N';
+
 $parser = new Parser($input);
-$value  = $parser->parse();
+
+$value = $parser->parse();
+```
+
+If many values need to be parsed, a single ```Parser``` instance can be used:
+
+```php
+$input1 = '56.242 E';
+$input2 = '40:26:46 S';
+
+$parser = new Parser();
+
+$value1 = $parser->parse($input1);
+$value2 = $parser->parse($input2);
 ```
 
 ## Supported Formats
@@ -75,3 +91,7 @@ Both single values and pairs are supported. Some samples of supported formats ar
 ## Return
 
 The parser will return a integer/float or an array containing a pair of these values.
+
+## Exceptions
+
+The ```Lexer``` and ```Parser``` will throw exceptions implementing interface ```CrEOF\Geo\String\Exception\ExceptionInterface```.

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
         "psr-0": {
             "CrEOF\\Geo\\String": "lib/"
         }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "CrEOF\\Geo\\String\\Tests": "tests/"
+        }
     }
 }

--- a/lib/CrEOF/Geo/String/Lexer.php
+++ b/lib/CrEOF/Geo/String/Lexer.php
@@ -64,15 +64,13 @@ class Lexer extends AbstractLexer
     {
         switch (true) {
             case (is_numeric($value)):
-                if (false !== strpos($value, '.')) {
-                    $value = (float) $value;
+                $value += 0;
 
-                    return self::T_FLOAT;
+                if (is_int($value)) {
+                    return self::T_INTEGER;
                 }
 
-                $value = (int) $value;
-
-                return self::T_INTEGER;
+                return self::T_FLOAT;
             case (':' === $value):
                 return self::T_COLON;
             case ('\'' === $value):

--- a/lib/CrEOF/Geo/String/Lexer.php
+++ b/lib/CrEOF/Geo/String/Lexer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2015 Derek J. Lambert
+ * Copyright (C) 2016 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lib/CrEOF/Geo/String/Lexer.php
+++ b/lib/CrEOF/Geo/String/Lexer.php
@@ -48,11 +48,13 @@ class Lexer extends AbstractLexer
     const T_DEGREE       = 14;
 
     /**
-     * @param string $input
+     * @param string|null $input
      */
-    public function __construct($input)
+    public function __construct($input = null)
     {
-        $this->setInput($input);
+        if (null !== $input) {
+            $this->setInput($input);
+        }
     }
 
     /**

--- a/lib/CrEOF/Geo/String/Parser.php
+++ b/lib/CrEOF/Geo/String/Parser.php
@@ -315,7 +315,7 @@ class Parser
             }
 
             // Get fractional minutes
-            $minutes = $minutes / 60;
+            $minutes /= 60;
 
             // Match minutes symbol
             $this->symbol();
@@ -346,7 +346,7 @@ class Parser
             }
 
             // Get fractional seconds
-            $seconds = $seconds / 3600;
+            $seconds /= 3600;
 
             // Match seconds symbol if requirement not colon
             if (Lexer::T_COLON !== $this->nextSymbol) {
@@ -430,7 +430,7 @@ class Parser
 
         // Throw exception if value is out of range
         if ($value > $range) {
-            throw $this->rangeError('Degrees', $range, (-1 * $range));
+            throw $this->rangeError('Degrees', $range, -1 * $range);
         }
 
         // Return value with sign

--- a/lib/CrEOF/Geo/String/Parser.php
+++ b/lib/CrEOF/Geo/String/Parser.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2015 Derek J. Lambert
+ * Copyright (C) 2016 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lib/CrEOF/Geo/String/Parser.php
+++ b/lib/CrEOF/Geo/String/Parser.php
@@ -42,11 +42,6 @@ class Parser
     private $input;
 
     /**
-     * @var Lexer
-     */
-    private $lexer;
-
-    /**
      * @var int
      */
     private $nextCardinal;
@@ -57,29 +52,48 @@ class Parser
     private $nextSymbol;
 
     /**
+     * @var Lexer
+     */
+    private static $lexer;
+
+    /**
      * Constructor
      *
      * Setup up instance properties
      *
-     * @param string $input
+     * @param string|null $input
      */
-    public function __construct($input)
+    public function __construct($input = null)
     {
-        // Save input string for use in messages
-        $this->input = $input;
-        // Create new Lexer and tokenize input string
-        $this->lexer = new Lexer($input);
+        if (null === self::$lexer) {
+            self::$lexer = new Lexer();
+        }
+
+        if (null !== $input) {
+            $this->input = $input;
+        }
     }
 
     /**
      * Parse input string
      *
+     * @param string|null $input
+     *
      * @return float|int|array
      */
-    public function parse()
+    public function parse($input = null)
     {
+        if (null !== $input) {
+            $this->input = $input;
+        }
+
+        $this->nextCardinal = null;
+        $this->nextSymbol   = null;
+
+        self::$lexer->setInput($this->input);
+
         // Move Lexer to first token
-        $this->lexer->moveNext();
+        self::$lexer->moveNext();
 
         // Parse and return value
         return $this->point();
@@ -97,12 +111,12 @@ class Parser
         $x = $this->coordinate();
 
         // If no additional tokens return single coordinate
-        if (null === $this->lexer->lookahead) {
+        if (null === self::$lexer->lookahead) {
             return $x;
         }
 
         // Coordinate pairs may be separated by a comma
-        if ($this->lexer->isNextToken(Lexer::T_COMMA)) {
+        if (self::$lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
         }
 
@@ -110,7 +124,7 @@ class Parser
         $y = $this->coordinate();
 
         // There should be no additional tokens
-        if (null !== $this->lexer->lookahead) {
+        if (null !== self::$lexer->lookahead) {
             throw $this->syntaxError('end of string');
         }
 
@@ -129,7 +143,7 @@ class Parser
         $sign = false;
 
         // Match sign if cardinal direction has not been seen
-        if (! ($this->nextCardinal > 0) && $this->lexer->isNextTokenAny(array(Lexer::T_PLUS, Lexer::T_MINUS))) {
+        if (! ($this->nextCardinal > 0) && self::$lexer->isNextTokenAny(array(Lexer::T_PLUS, Lexer::T_MINUS))) {
             $sign = $this->sign();
         }
 
@@ -138,7 +152,7 @@ class Parser
 
         // If sign not matched determine sign from cardinal direction when required
         // or if cardinal direction is present and this is first coordinate in a pair
-        if (false === $sign && ($this->nextCardinal > 0 || (null === $this->nextCardinal && $this->lexer->isNextTokenAny(array(Lexer::T_CARDINAL_LAT, Lexer::T_CARDINAL_LON))))) {
+        if (false === $sign && ($this->nextCardinal > 0 || (null === $this->nextCardinal && self::$lexer->isNextTokenAny(array(Lexer::T_CARDINAL_LAT, Lexer::T_CARDINAL_LON))))) {
             return $this->cardinal($coordinate);
         }
 
@@ -156,7 +170,7 @@ class Parser
      */
     private function sign()
     {
-        if ($this->lexer->isNextToken(Lexer::T_PLUS)) {
+        if (self::$lexer->isNextToken(Lexer::T_PLUS)) {
             // Match plus and set sign
             $this->match(Lexer::T_PLUS);
 
@@ -182,12 +196,12 @@ class Parser
         }
 
         // If degrees is a float there will be no minutes or seconds
-        if ($this->lexer->isNextToken(Lexer::T_FLOAT)) {
+        if (self::$lexer->isNextToken(Lexer::T_FLOAT)) {
             // Get degree value
             $degrees = $this->match(Lexer::T_FLOAT);
 
             // Degree float values may be followed by degree symbol
-            if ($this->lexer->isNextToken(Lexer::T_DEGREE)) {
+            if (self::$lexer->isNextToken(Lexer::T_DEGREE)) {
                 $this->match(Lexer::T_DEGREE);
 
                 // Set symbol requirement for next value in pair
@@ -207,10 +221,10 @@ class Parser
         }
 
         // Grab peek of next token since we can't array dereference result in PHP 5.3
-        $glimpse = $this->lexer->glimpse();
+        $glimpse = self::$lexer->glimpse();
 
         // If a colon hasn't been matched, and next token is a number followed by degree symbol, when tuple separator is space instead of comma, this value is complete
-        if (Lexer::T_COLON !== $this->nextSymbol && $this->lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT)) && Lexer::T_DEGREE === $glimpse['type']) {
+        if (Lexer::T_COLON !== $this->nextSymbol && self::$lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT)) && Lexer::T_DEGREE === $glimpse['type']) {
             return $degrees;
         }
 
@@ -229,7 +243,7 @@ class Parser
     private function symbol()
     {
         // If symbol requirement not set match colon if present
-        if (null === $this->nextSymbol && $this->lexer->isNextToken(Lexer::T_COLON)) {
+        if (null === $this->nextSymbol && self::$lexer->isNextToken(Lexer::T_COLON)) {
             $this->match(Lexer::T_COLON);
 
             // Set symbol requirement for any remaining value
@@ -237,7 +251,7 @@ class Parser
         }
 
         // If symbol requirement not set match degree if present
-        if (null === $this->nextSymbol && $this->lexer->isNextToken(Lexer::T_DEGREE)) {
+        if (null === $this->nextSymbol && self::$lexer->isNextToken(Lexer::T_DEGREE)) {
             $this->match(Lexer::T_DEGREE);
 
             // Set requirement for any remaining value
@@ -279,7 +293,7 @@ class Parser
     private function minutes()
     {
         // If using colon or minutes is an integer parse value
-        if (Lexer::T_COLON === $this->nextSymbol || $this->lexer->isNextToken(Lexer::T_INTEGER)) {
+        if (Lexer::T_COLON === $this->nextSymbol || self::$lexer->isNextToken(Lexer::T_INTEGER)) {
             $minutes = $this->match(Lexer::T_INTEGER);
 
             // Throw exception if minutes are greater than 60
@@ -291,7 +305,7 @@ class Parser
             $minutes = $minutes / 60;
 
             // If using colon and one doesn't follow value is done
-            if (Lexer::T_COLON === $this->nextSymbol && ! $this->lexer->isNextToken(Lexer::T_COLON)) {
+            if (Lexer::T_COLON === $this->nextSymbol && ! self::$lexer->isNextToken(Lexer::T_COLON)) {
                 return $minutes;
             }
 
@@ -306,7 +320,7 @@ class Parser
         }
 
         // If minutes is a float there will be no seconds
-        if ($this->lexer->isNextToken(Lexer::T_FLOAT)) {
+        if (self::$lexer->isNextToken(Lexer::T_FLOAT)) {
             $minutes = $this->match(Lexer::T_FLOAT);
 
             // Throw exception if minutes are greater than 60
@@ -337,7 +351,7 @@ class Parser
     private function seconds()
     {
         // Seconds value can be an integer or float
-        if ($this->lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT))) {
+        if (self::$lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT))) {
             $seconds = $this->number();
 
             // Throw exception if seconds are greater than 60
@@ -370,12 +384,12 @@ class Parser
     private function number()
     {
         // If next token is a float match and return it
-        if ($this->lexer->isNextToken(Lexer::T_FLOAT)) {
+        if (self::$lexer->isNextToken(Lexer::T_FLOAT)) {
             return $this->match(Lexer::T_FLOAT);
         }
 
         // If next token is an integer match and return it
-        if ($this->lexer->isNextToken(Lexer::T_INTEGER)) {
+        if (self::$lexer->isNextToken(Lexer::T_INTEGER)) {
             return $this->match(Lexer::T_INTEGER);
         }
 
@@ -395,7 +409,7 @@ class Parser
     {
         // If cardinal direction was not on previous coordinate it can be anything
         if (null === $this->nextCardinal) {
-            $this->nextCardinal = Lexer::T_CARDINAL_LON === $this->lexer->lookahead['type'] ? Lexer::T_CARDINAL_LON : Lexer::T_CARDINAL_LAT;
+            $this->nextCardinal = Lexer::T_CARDINAL_LON === self::$lexer->lookahead['type'] ? Lexer::T_CARDINAL_LON : Lexer::T_CARDINAL_LAT;
         }
 
         // Match cardinal direction
@@ -448,15 +462,15 @@ class Parser
     private function match($token)
     {
         // If next token isn't type specified throw error
-        if (! $this->lexer->isNextToken($token)) {
-            throw $this->syntaxError($this->lexer->getLiteral($token));
+        if (! self::$lexer->isNextToken($token)) {
+            throw $this->syntaxError(self::$lexer->getLiteral($token));
         }
 
         // Move lexer to next token
-        $this->lexer->moveNext();
+        self::$lexer->moveNext();
 
         // Return the token value
-        return $this->lexer->token['value'];
+        return self::$lexer->token['value'];
     }
 
     /**
@@ -469,8 +483,8 @@ class Parser
     private function syntaxError($expected)
     {
         $expected = sprintf('Expected %s, got', $expected);
-        $token    = $this->lexer->lookahead;
-        $found    = null === $this->lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token['value']);
+        $token    = self::$lexer->lookahead;
+        $found    = null === self::$lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token['value']);
 
         $message = sprintf(
             '[Syntax Error] line 0, col %d: Error: %s %s in value "%s"',

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit backupGlobals="false"
-         colors="true"
-         bootstrap="./tests/TestInit.php"
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+        backupGlobals="false"
+        colors="true"
+        bootstrap="./vendor/autoload.php"
         >
 
     <testsuites>
-        <testsuite>
+        <testsuite name="Tests">
             <directory>./tests/CrEOF/Geo/String/Tests</directory>
         </testsuite>
     </testsuites>
 
     <filter>
-        <blacklist>
-            <directory suffix=".php">./vendor</directory>
-        </blacklist>
+        <whitelist>
+            <directory suffix=".php">lib</directory>
+            <exclude>
+                <directory>tests</directory>
+                <directory>vendor</directory>
+            </exclude>
+        </whitelist>
     </filter>
 </phpunit>

--- a/tests/CrEOF/Geo/String/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/String/Tests/LexerTest.php
@@ -57,6 +57,36 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     {
         return array (
             array(
+                '15',
+                array(
+                    array('value' => 15, 'type' => Lexer::T_INTEGER, 'position' => 0),
+                )
+            ),
+            array(
+                '1E5',
+                array(
+                    array('value' => 100000, 'type' => Lexer::T_FLOAT, 'position' => 0),
+                )
+            ),
+            array(
+                '1e5',
+                array(
+                    array('value' => 100000, 'type' => Lexer::T_FLOAT, 'position' => 0),
+                )
+            ),
+            array(
+                '1.5E5',
+                array(
+                    array('value' => 150000, 'type' => Lexer::T_FLOAT, 'position' => 0),
+                )
+            ),
+            array(
+                '1E-5',
+                array(
+                    array('value' => 0.00001, 'type' => Lexer::T_FLOAT, 'position' => 0),
+                )
+            ),
+            array(
                 '40° 26\' 46" N',
                 array(
                     array('value' => 40, 'type' => Lexer::T_INTEGER, 'position' => 0),

--- a/tests/CrEOF/Geo/String/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/String/Tests/LexerTest.php
@@ -50,6 +50,21 @@ class LexerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testReusedLexer()
+    {
+        $lexer = new Lexer();
+
+        foreach ($this->testDataSource() as $data) {
+            $index = 0;
+
+            $lexer->setInput($data[0]);
+
+            while (null !== $actual = $lexer->peek()) {
+                $this->assertEquals($data[1][$index++], $actual);
+            }
+        }
+    }
+
     /**
      * @return array[]
      */

--- a/tests/CrEOF/Geo/String/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/String/Tests/ParserTest.php
@@ -72,6 +72,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         return array(
             array('40', 40),
             array('-40', -40),
+            array('1E5', 100000),
+            array('1e5', 100000),
+            array('1e5°', 100000),
             array('40°', 40),
             array('-40°', -40),
             array('40° N', 40),

--- a/tests/CrEOF/Geo/String/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/String/Tests/ParserTest.php
@@ -48,6 +48,17 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $value);
     }
 
+    public function testParserReuse()
+    {
+        $parser = new Parser();
+
+        foreach ($this->dataSourceGood() as $data) {
+            $value = $parser->parse($data[0]);
+
+            $this->assertEquals($data[1], $value);
+        }
+    }
+
     /**
      * @param string $input
      * @param string $exception

--- a/tests/TestInit.php
+++ b/tests/TestInit.php
@@ -1,9 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';
-
-error_reporting(E_ALL | E_STRICT);
-
-$loader = new \Composer\Autoload\ClassLoader();
-$loader->add('CrEOF\Geo\String\Tests', __DIR__);
-$loader->register();


### PR DESCRIPTION
Properly parse numbers returned from the Lexer in scientific notation.
Cleanup test init and PHPUnit config.
Make constructor parameter optional for Lexer and Parser so instances can be reused.
Reuse Lexer instance used in Parser.
Update documentation with new usage pattern.