### PR TITLE
Release 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Support for numbers in scientific notation.
 ### Changed
+- Parser constructor no longer requires a value enabling instance reuse.
+- Lexer constructor no longer requires a value enabling instance reuse.
+- Lexer instance used in Parser now a static var.
+- Tests now use Composer autoload.
+- PHPUnit XML now conformant.
+- Documentation updated with new usage pattern.
+### Removed
+- TestInit no longer needed
 
 ## [2.0.0] - 2015-11-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,24 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Support for numbers in scientific notation.
+
 ### Changed
-- Parser constructor no longer requires a value enabling instance reuse.
-- Lexer constructor no longer requires a value enabling instance reuse.
+
+### Removed
+
+## [2.1.0] - 2016-05-03
+### Added
+- Support for numbers in scientific notation.
+
+### Changed
+- Parser constructor no longer requires a value, enabling instance reuse.
+- Lexer constructor no longer requires a value, enabling instance reuse.
 - Tests now use Composer autoload.
-- PHPUnit XML now conformant.
+- PHPUnit config XML now conforms to XSD.
 - Documentation updated with new usage pattern.
 - Move non-value comparison into if statement in Lexer::getType().
 - Test case and test data cleanup.
+
 ### Removed
 - TestInit no longer needed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Parser constructor no longer requires a value enabling instance reuse.
 - Lexer constructor no longer requires a value enabling instance reuse.
-- Lexer instance used in Parser now a static var.
 - Tests now use Composer autoload.
 - PHPUnit XML now conformant.
 - Documentation updated with new usage pattern.
+- Move non-value comparison into if statement in Lexer::getType().
+- Test case and test data cleanup.
 ### Removed
 - TestInit no longer needed
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Both single values and pairs are supported. Some samples of supported formats ar
  * 99:58:56 W
  * 44:58:53.9 N
 
-8. Two of any one format separated by space(s)
+8. Two of any one format separated by whitespace
 
 9. Two of any one format separated by a comma
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,31 @@
 [![Test Coverage](https://codeclimate.com/github/creof/geo-parser/badges/coverage.svg)](https://codeclimate.com/github/creof/geo-parser/coverage)
 [![Build Status](https://travis-ci.org/creof/geo-parser.svg)](https://travis-ci.org/creof/geo-parser)
 
-Lexer and parser library for geometric and geographic string values.
+Lexer and parser library for geometric and geographic point string values.
 
 ## Usage
-Pass value to be parsed in the constructor, then call parse() on the created object.
+
+There are two use patterns for the parser. The value to be parsed can be passed into the constructor, then parse()
+called on the returned ```Parser``` object:
 
 ```php
 $input  = '79°56′55″W, 40°26′46″N';
+
 $parser = new Parser($input);
-$value  = $parser->parse();
+
+$value = $parser->parse();
+```
+
+If many values need to be parsed, a single ```Parser``` instance can be used:
+
+```php
+$input1 = '56.242 E';
+$input2 = '40:26:46 S';
+
+$parser = new Parser();
+
+$value1 = $parser->parse($input1);
+$value2 = $parser->parse($input2);
 ```
 
 ## Supported Formats
@@ -75,3 +91,7 @@ Both single values and pairs are supported. Some samples of supported formats ar
 ## Return
 
 The parser will return a integer/float or an array containing a pair of these values.
+
+## Exceptions
+
+The ```Lexer``` and ```Parser``` will throw exceptions implementing interface ```CrEOF\Geo\String\Exception\ExceptionInterface```.

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
         "psr-0": {
             "CrEOF\\Geo\\String": "lib/"
         }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "CrEOF\\Geo\\String\\Tests": "tests/"
+        }
     }
 }

--- a/lib/CrEOF/Geo/String/Lexer.php
+++ b/lib/CrEOF/Geo/String/Lexer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2015 Derek J. Lambert
+ * Copyright (C) 2016 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,11 +48,13 @@ class Lexer extends AbstractLexer
     const T_DEGREE       = 14;
 
     /**
-     * @param string $input
+     * @param string|null $input
      */
-    public function __construct($input)
+    public function __construct($input = null)
     {
-        $this->setInput($input);
+        if (null !== $input) {
+            $this->setInput($input);
+        }
     }
 
     /**
@@ -64,15 +66,13 @@ class Lexer extends AbstractLexer
     {
         switch (true) {
             case (is_numeric($value)):
-                if (false !== strpos($value, '.')) {
-                    $value = (float) $value;
+                $value += 0;
 
-                    return self::T_FLOAT;
+                if (is_int($value)) {
+                    return self::T_INTEGER;
                 }
 
-                $value = (int) $value;
-
-                return self::T_INTEGER;
+                return self::T_FLOAT;
             case (':' === $value):
                 return self::T_COLON;
             case ('\'' === $value):

--- a/lib/CrEOF/Geo/String/Lexer.php
+++ b/lib/CrEOF/Geo/String/Lexer.php
@@ -64,36 +64,38 @@ class Lexer extends AbstractLexer
      */
     protected function getType(&$value)
     {
-        switch (true) {
-            case (is_numeric($value)):
-                $value += 0;
+        if (is_numeric($value)) {
+            $value += 0;
 
-                if (is_int($value)) {
-                    return self::T_INTEGER;
-                }
+            if (is_int($value)) {
+                return self::T_INTEGER;
+            }
 
-                return self::T_FLOAT;
-            case (':' === $value):
+            return self::T_FLOAT;
+        }
+
+        switch ($value) {
+            case ':':
                 return self::T_COLON;
-            case ('\'' === $value):
-            case ("\xe2\x80\xb2" === $value): // prime
+            case '\'':
+            case "\xe2\x80\xb2": // prime
                 return self::T_APOSTROPHE;
-            case ('"' === $value):
-            case ("\xe2\x80\xb3" === $value): // double prime
+            case '"':
+            case "\xe2\x80\xb3": // double prime
                 return self::T_QUOTE;
-            case (',' === $value):
+            case ',':
                 return self::T_COMMA;
-            case ('-' === $value):
+            case '-':
                 return self::T_MINUS;
-            case ('+' === $value):
+            case '+':
                 return self::T_PLUS;
-            case ('°' === $value):
+            case '°':
                 return self::T_DEGREE;
-            case ('N' === strtoupper($value)):
-            case ('S' === strtoupper($value)):
+            case 'N':
+            case 'S':
                 return self::T_CARDINAL_LAT;
-            case ('E' === strtoupper($value)):
-            case ('W' === strtoupper($value)):
+            case 'E':
+            case 'W':
                 return self::T_CARDINAL_LON;
             default:
                 return self::T_NONE;

--- a/lib/CrEOF/Geo/String/Parser.php
+++ b/lib/CrEOF/Geo/String/Parser.php
@@ -54,7 +54,7 @@ class Parser
     /**
      * @var Lexer
      */
-    private static $lexer;
+    private $lexer;
 
     /**
      * Constructor
@@ -65,9 +65,7 @@ class Parser
      */
     public function __construct($input = null)
     {
-        if (null === self::$lexer) {
-            self::$lexer = new Lexer();
-        }
+        $this->lexer = new Lexer();
 
         if (null !== $input) {
             $this->input = $input;
@@ -90,10 +88,10 @@ class Parser
         $this->nextCardinal = null;
         $this->nextSymbol   = null;
 
-        self::$lexer->setInput($this->input);
+        $this->lexer->setInput($this->input);
 
         // Move Lexer to first token
-        self::$lexer->moveNext();
+        $this->lexer->moveNext();
 
         // Parse and return value
         return $this->point();
@@ -111,12 +109,12 @@ class Parser
         $x = $this->coordinate();
 
         // If no additional tokens return single coordinate
-        if (null === self::$lexer->lookahead) {
+        if (null === $this->lexer->lookahead) {
             return $x;
         }
 
         // Coordinate pairs may be separated by a comma
-        if (self::$lexer->isNextToken(Lexer::T_COMMA)) {
+        if ($this->lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
         }
 
@@ -124,7 +122,7 @@ class Parser
         $y = $this->coordinate();
 
         // There should be no additional tokens
-        if (null !== self::$lexer->lookahead) {
+        if (null !== $this->lexer->lookahead) {
             throw $this->syntaxError('end of string');
         }
 
@@ -143,7 +141,7 @@ class Parser
         $sign = false;
 
         // Match sign if cardinal direction has not been seen
-        if (! ($this->nextCardinal > 0) && self::$lexer->isNextTokenAny(array(Lexer::T_PLUS, Lexer::T_MINUS))) {
+        if (! ($this->nextCardinal > 0) && $this->lexer->isNextTokenAny(array(Lexer::T_PLUS, Lexer::T_MINUS))) {
             $sign = $this->sign();
         }
 
@@ -152,7 +150,7 @@ class Parser
 
         // If sign not matched determine sign from cardinal direction when required
         // or if cardinal direction is present and this is first coordinate in a pair
-        if (false === $sign && ($this->nextCardinal > 0 || (null === $this->nextCardinal && self::$lexer->isNextTokenAny(array(Lexer::T_CARDINAL_LAT, Lexer::T_CARDINAL_LON))))) {
+        if (false === $sign && ($this->nextCardinal > 0 || (null === $this->nextCardinal && $this->lexer->isNextTokenAny(array(Lexer::T_CARDINAL_LAT, Lexer::T_CARDINAL_LON))))) {
             return $this->cardinal($coordinate);
         }
 
@@ -170,7 +168,7 @@ class Parser
      */
     private function sign()
     {
-        if (self::$lexer->isNextToken(Lexer::T_PLUS)) {
+        if ($this->lexer->isNextToken(Lexer::T_PLUS)) {
             // Match plus and set sign
             $this->match(Lexer::T_PLUS);
 
@@ -196,12 +194,12 @@ class Parser
         }
 
         // If degrees is a float there will be no minutes or seconds
-        if (self::$lexer->isNextToken(Lexer::T_FLOAT)) {
+        if ($this->lexer->isNextToken(Lexer::T_FLOAT)) {
             // Get degree value
             $degrees = $this->match(Lexer::T_FLOAT);
 
             // Degree float values may be followed by degree symbol
-            if (self::$lexer->isNextToken(Lexer::T_DEGREE)) {
+            if ($this->lexer->isNextToken(Lexer::T_DEGREE)) {
                 $this->match(Lexer::T_DEGREE);
 
                 // Set symbol requirement for next value in pair
@@ -221,10 +219,10 @@ class Parser
         }
 
         // Grab peek of next token since we can't array dereference result in PHP 5.3
-        $glimpse = self::$lexer->glimpse();
+        $glimpse = $this->lexer->glimpse();
 
         // If a colon hasn't been matched, and next token is a number followed by degree symbol, when tuple separator is space instead of comma, this value is complete
-        if (Lexer::T_COLON !== $this->nextSymbol && self::$lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT)) && Lexer::T_DEGREE === $glimpse['type']) {
+        if (Lexer::T_COLON !== $this->nextSymbol && $this->lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT)) && Lexer::T_DEGREE === $glimpse['type']) {
             return $degrees;
         }
 
@@ -243,7 +241,7 @@ class Parser
     private function symbol()
     {
         // If symbol requirement not set match colon if present
-        if (null === $this->nextSymbol && self::$lexer->isNextToken(Lexer::T_COLON)) {
+        if (null === $this->nextSymbol && $this->lexer->isNextToken(Lexer::T_COLON)) {
             $this->match(Lexer::T_COLON);
 
             // Set symbol requirement for any remaining value
@@ -251,7 +249,7 @@ class Parser
         }
 
         // If symbol requirement not set match degree if present
-        if (null === $this->nextSymbol && self::$lexer->isNextToken(Lexer::T_DEGREE)) {
+        if (null === $this->nextSymbol && $this->lexer->isNextToken(Lexer::T_DEGREE)) {
             $this->match(Lexer::T_DEGREE);
 
             // Set requirement for any remaining value
@@ -293,7 +291,7 @@ class Parser
     private function minutes()
     {
         // If using colon or minutes is an integer parse value
-        if (Lexer::T_COLON === $this->nextSymbol || self::$lexer->isNextToken(Lexer::T_INTEGER)) {
+        if (Lexer::T_COLON === $this->nextSymbol || $this->lexer->isNextToken(Lexer::T_INTEGER)) {
             $minutes = $this->match(Lexer::T_INTEGER);
 
             // Throw exception if minutes are greater than 60
@@ -305,7 +303,7 @@ class Parser
             $minutes = $minutes / 60;
 
             // If using colon and one doesn't follow value is done
-            if (Lexer::T_COLON === $this->nextSymbol && ! self::$lexer->isNextToken(Lexer::T_COLON)) {
+            if (Lexer::T_COLON === $this->nextSymbol && ! $this->lexer->isNextToken(Lexer::T_COLON)) {
                 return $minutes;
             }
 
@@ -320,7 +318,7 @@ class Parser
         }
 
         // If minutes is a float there will be no seconds
-        if (self::$lexer->isNextToken(Lexer::T_FLOAT)) {
+        if ($this->lexer->isNextToken(Lexer::T_FLOAT)) {
             $minutes = $this->match(Lexer::T_FLOAT);
 
             // Throw exception if minutes are greater than 60
@@ -351,7 +349,7 @@ class Parser
     private function seconds()
     {
         // Seconds value can be an integer or float
-        if (self::$lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT))) {
+        if ($this->lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT))) {
             $seconds = $this->number();
 
             // Throw exception if seconds are greater than 60
@@ -384,12 +382,12 @@ class Parser
     private function number()
     {
         // If next token is a float match and return it
-        if (self::$lexer->isNextToken(Lexer::T_FLOAT)) {
+        if ($this->lexer->isNextToken(Lexer::T_FLOAT)) {
             return $this->match(Lexer::T_FLOAT);
         }
 
         // If next token is an integer match and return it
-        if (self::$lexer->isNextToken(Lexer::T_INTEGER)) {
+        if ($this->lexer->isNextToken(Lexer::T_INTEGER)) {
             return $this->match(Lexer::T_INTEGER);
         }
 
@@ -409,7 +407,7 @@ class Parser
     {
         // If cardinal direction was not on previous coordinate it can be anything
         if (null === $this->nextCardinal) {
-            $this->nextCardinal = Lexer::T_CARDINAL_LON === self::$lexer->lookahead['type'] ? Lexer::T_CARDINAL_LON : Lexer::T_CARDINAL_LAT;
+            $this->nextCardinal = Lexer::T_CARDINAL_LON === $this->lexer->lookahead['type'] ? Lexer::T_CARDINAL_LON : Lexer::T_CARDINAL_LAT;
         }
 
         // Match cardinal direction
@@ -462,15 +460,15 @@ class Parser
     private function match($token)
     {
         // If next token isn't type specified throw error
-        if (! self::$lexer->isNextToken($token)) {
-            throw $this->syntaxError(self::$lexer->getLiteral($token));
+        if (! $this->lexer->isNextToken($token)) {
+            throw $this->syntaxError($this->lexer->getLiteral($token));
         }
 
         // Move lexer to next token
-        self::$lexer->moveNext();
+        $this->lexer->moveNext();
 
         // Return the token value
-        return self::$lexer->token['value'];
+        return $this->lexer->token['value'];
     }
 
     /**
@@ -483,8 +481,8 @@ class Parser
     private function syntaxError($expected)
     {
         $expected = sprintf('Expected %s, got', $expected);
-        $token    = self::$lexer->lookahead;
-        $found    = null === self::$lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token['value']);
+        $token    = $this->lexer->lookahead;
+        $found    = null === $this->lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token['value']);
 
         $message = sprintf(
             '[Syntax Error] line 0, col %d: Error: %s %s in value "%s"',

--- a/lib/CrEOF/Geo/String/Parser.php
+++ b/lib/CrEOF/Geo/String/Parser.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2015 Derek J. Lambert
+ * Copyright (C) 2016 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,11 +42,6 @@ class Parser
     private $input;
 
     /**
-     * @var Lexer
-     */
-    private $lexer;
-
-    /**
      * @var int
      */
     private $nextCardinal;
@@ -57,29 +52,48 @@ class Parser
     private $nextSymbol;
 
     /**
+     * @var Lexer
+     */
+    private static $lexer;
+
+    /**
      * Constructor
      *
      * Setup up instance properties
      *
-     * @param string $input
+     * @param string|null $input
      */
-    public function __construct($input)
+    public function __construct($input = null)
     {
-        // Save input string for use in messages
-        $this->input = $input;
-        // Create new Lexer and tokenize input string
-        $this->lexer = new Lexer($input);
+        if (null === self::$lexer) {
+            self::$lexer = new Lexer();
+        }
+
+        if (null !== $input) {
+            $this->input = $input;
+        }
     }
 
     /**
      * Parse input string
      *
+     * @param string|null $input
+     *
      * @return float|int|array
      */
-    public function parse()
+    public function parse($input = null)
     {
+        if (null !== $input) {
+            $this->input = $input;
+        }
+
+        $this->nextCardinal = null;
+        $this->nextSymbol   = null;
+
+        self::$lexer->setInput($this->input);
+
         // Move Lexer to first token
-        $this->lexer->moveNext();
+        self::$lexer->moveNext();
 
         // Parse and return value
         return $this->point();
@@ -97,12 +111,12 @@ class Parser
         $x = $this->coordinate();
 
         // If no additional tokens return single coordinate
-        if (null === $this->lexer->lookahead) {
+        if (null === self::$lexer->lookahead) {
             return $x;
         }
 
         // Coordinate pairs may be separated by a comma
-        if ($this->lexer->isNextToken(Lexer::T_COMMA)) {
+        if (self::$lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
         }
 
@@ -110,7 +124,7 @@ class Parser
         $y = $this->coordinate();
 
         // There should be no additional tokens
-        if (null !== $this->lexer->lookahead) {
+        if (null !== self::$lexer->lookahead) {
             throw $this->syntaxError('end of string');
         }
 
@@ -129,7 +143,7 @@ class Parser
         $sign = false;
 
         // Match sign if cardinal direction has not been seen
-        if (! ($this->nextCardinal > 0) && $this->lexer->isNextTokenAny(array(Lexer::T_PLUS, Lexer::T_MINUS))) {
+        if (! ($this->nextCardinal > 0) && self::$lexer->isNextTokenAny(array(Lexer::T_PLUS, Lexer::T_MINUS))) {
             $sign = $this->sign();
         }
 
@@ -138,7 +152,7 @@ class Parser
 
         // If sign not matched determine sign from cardinal direction when required
         // or if cardinal direction is present and this is first coordinate in a pair
-        if (false === $sign && ($this->nextCardinal > 0 || (null === $this->nextCardinal && $this->lexer->isNextTokenAny(array(Lexer::T_CARDINAL_LAT, Lexer::T_CARDINAL_LON))))) {
+        if (false === $sign && ($this->nextCardinal > 0 || (null === $this->nextCardinal && self::$lexer->isNextTokenAny(array(Lexer::T_CARDINAL_LAT, Lexer::T_CARDINAL_LON))))) {
             return $this->cardinal($coordinate);
         }
 
@@ -156,7 +170,7 @@ class Parser
      */
     private function sign()
     {
-        if ($this->lexer->isNextToken(Lexer::T_PLUS)) {
+        if (self::$lexer->isNextToken(Lexer::T_PLUS)) {
             // Match plus and set sign
             $this->match(Lexer::T_PLUS);
 
@@ -182,12 +196,12 @@ class Parser
         }
 
         // If degrees is a float there will be no minutes or seconds
-        if ($this->lexer->isNextToken(Lexer::T_FLOAT)) {
+        if (self::$lexer->isNextToken(Lexer::T_FLOAT)) {
             // Get degree value
             $degrees = $this->match(Lexer::T_FLOAT);
 
             // Degree float values may be followed by degree symbol
-            if ($this->lexer->isNextToken(Lexer::T_DEGREE)) {
+            if (self::$lexer->isNextToken(Lexer::T_DEGREE)) {
                 $this->match(Lexer::T_DEGREE);
 
                 // Set symbol requirement for next value in pair
@@ -207,10 +221,10 @@ class Parser
         }
 
         // Grab peek of next token since we can't array dereference result in PHP 5.3
-        $glimpse = $this->lexer->glimpse();
+        $glimpse = self::$lexer->glimpse();
 
         // If a colon hasn't been matched, and next token is a number followed by degree symbol, when tuple separator is space instead of comma, this value is complete
-        if (Lexer::T_COLON !== $this->nextSymbol && $this->lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT)) && Lexer::T_DEGREE === $glimpse['type']) {
+        if (Lexer::T_COLON !== $this->nextSymbol && self::$lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT)) && Lexer::T_DEGREE === $glimpse['type']) {
             return $degrees;
         }
 
@@ -229,7 +243,7 @@ class Parser
     private function symbol()
     {
         // If symbol requirement not set match colon if present
-        if (null === $this->nextSymbol && $this->lexer->isNextToken(Lexer::T_COLON)) {
+        if (null === $this->nextSymbol && self::$lexer->isNextToken(Lexer::T_COLON)) {
             $this->match(Lexer::T_COLON);
 
             // Set symbol requirement for any remaining value
@@ -237,7 +251,7 @@ class Parser
         }
 
         // If symbol requirement not set match degree if present
-        if (null === $this->nextSymbol && $this->lexer->isNextToken(Lexer::T_DEGREE)) {
+        if (null === $this->nextSymbol && self::$lexer->isNextToken(Lexer::T_DEGREE)) {
             $this->match(Lexer::T_DEGREE);
 
             // Set requirement for any remaining value
@@ -279,7 +293,7 @@ class Parser
     private function minutes()
     {
         // If using colon or minutes is an integer parse value
-        if (Lexer::T_COLON === $this->nextSymbol || $this->lexer->isNextToken(Lexer::T_INTEGER)) {
+        if (Lexer::T_COLON === $this->nextSymbol || self::$lexer->isNextToken(Lexer::T_INTEGER)) {
             $minutes = $this->match(Lexer::T_INTEGER);
 
             // Throw exception if minutes are greater than 60
@@ -291,7 +305,7 @@ class Parser
             $minutes = $minutes / 60;
 
             // If using colon and one doesn't follow value is done
-            if (Lexer::T_COLON === $this->nextSymbol && ! $this->lexer->isNextToken(Lexer::T_COLON)) {
+            if (Lexer::T_COLON === $this->nextSymbol && ! self::$lexer->isNextToken(Lexer::T_COLON)) {
                 return $minutes;
             }
 
@@ -306,7 +320,7 @@ class Parser
         }
 
         // If minutes is a float there will be no seconds
-        if ($this->lexer->isNextToken(Lexer::T_FLOAT)) {
+        if (self::$lexer->isNextToken(Lexer::T_FLOAT)) {
             $minutes = $this->match(Lexer::T_FLOAT);
 
             // Throw exception if minutes are greater than 60
@@ -315,7 +329,7 @@ class Parser
             }
 
             // Get fractional minutes
-            $minutes = $minutes / 60;
+            $minutes /= 60;
 
             // Match minutes symbol
             $this->symbol();
@@ -337,7 +351,7 @@ class Parser
     private function seconds()
     {
         // Seconds value can be an integer or float
-        if ($this->lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT))) {
+        if (self::$lexer->isNextTokenAny(array(Lexer::T_INTEGER, Lexer::T_FLOAT))) {
             $seconds = $this->number();
 
             // Throw exception if seconds are greater than 60
@@ -346,7 +360,7 @@ class Parser
             }
 
             // Get fractional seconds
-            $seconds = $seconds / 3600;
+            $seconds /= 3600;
 
             // Match seconds symbol if requirement not colon
             if (Lexer::T_COLON !== $this->nextSymbol) {
@@ -370,12 +384,12 @@ class Parser
     private function number()
     {
         // If next token is a float match and return it
-        if ($this->lexer->isNextToken(Lexer::T_FLOAT)) {
+        if (self::$lexer->isNextToken(Lexer::T_FLOAT)) {
             return $this->match(Lexer::T_FLOAT);
         }
 
         // If next token is an integer match and return it
-        if ($this->lexer->isNextToken(Lexer::T_INTEGER)) {
+        if (self::$lexer->isNextToken(Lexer::T_INTEGER)) {
             return $this->match(Lexer::T_INTEGER);
         }
 
@@ -395,7 +409,7 @@ class Parser
     {
         // If cardinal direction was not on previous coordinate it can be anything
         if (null === $this->nextCardinal) {
-            $this->nextCardinal = Lexer::T_CARDINAL_LON === $this->lexer->lookahead['type'] ? Lexer::T_CARDINAL_LON : Lexer::T_CARDINAL_LAT;
+            $this->nextCardinal = Lexer::T_CARDINAL_LON === self::$lexer->lookahead['type'] ? Lexer::T_CARDINAL_LON : Lexer::T_CARDINAL_LAT;
         }
 
         // Match cardinal direction
@@ -430,7 +444,7 @@ class Parser
 
         // Throw exception if value is out of range
         if ($value > $range) {
-            throw $this->rangeError('Degrees', $range, (-1 * $range));
+            throw $this->rangeError('Degrees', $range, -1 * $range);
         }
 
         // Return value with sign
@@ -448,15 +462,15 @@ class Parser
     private function match($token)
     {
         // If next token isn't type specified throw error
-        if (! $this->lexer->isNextToken($token)) {
-            throw $this->syntaxError($this->lexer->getLiteral($token));
+        if (! self::$lexer->isNextToken($token)) {
+            throw $this->syntaxError(self::$lexer->getLiteral($token));
         }
 
         // Move lexer to next token
-        $this->lexer->moveNext();
+        self::$lexer->moveNext();
 
         // Return the token value
-        return $this->lexer->token['value'];
+        return self::$lexer->token['value'];
     }
 
     /**
@@ -469,8 +483,8 @@ class Parser
     private function syntaxError($expected)
     {
         $expected = sprintf('Expected %s, got', $expected);
-        $token    = $this->lexer->lookahead;
-        $found    = null === $this->lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token['value']);
+        $token    = self::$lexer->lookahead;
+        $found    = null === self::$lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token['value']);
 
         $message = sprintf(
             '[Syntax Error] line 0, col %d: Error: %s %s in value "%s"',

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
         backupGlobals="false"
         colors="true"
         bootstrap="./vendor/autoload.php"
-        >
+>
 
     <testsuites>
         <testsuite name="Tests">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit backupGlobals="false"
-         colors="true"
-         bootstrap="./tests/TestInit.php"
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+        backupGlobals="false"
+        colors="true"
+        bootstrap="./vendor/autoload.php"
         >
 
     <testsuites>
-        <testsuite>
+        <testsuite name="Tests">
             <directory>./tests/CrEOF/Geo/String/Tests</directory>
         </testsuite>
     </testsuites>
 
     <filter>
-        <blacklist>
-            <directory suffix=".php">./vendor</directory>
-        </blacklist>
+        <whitelist>
+            <directory suffix=".php">lib</directory>
+            <exclude>
+                <directory>tests</directory>
+                <directory>vendor</directory>
+            </exclude>
+        </whitelist>
     </filter>
 </phpunit>

--- a/tests/CrEOF/Geo/String/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/String/Tests/LexerTest.php
@@ -203,6 +203,16 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                     array('value' => 79.553, 'type' => Lexer::T_FLOAT, 'position' => 11),
                     array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 17),
                 )
+            ),
+            array(
+                'input'          => "40.4738° \t -79.553°",
+                'expectedTokens' => array(
+                    array('value' => 40.4738, 'type' => Lexer::T_FLOAT, 'position' => 0),
+                    array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 7),
+                    array('value' => '-', 'type' => Lexer::T_MINUS, 'position' => 12),
+                    array('value' => 79.553, 'type' => Lexer::T_FLOAT, 'position' => 13),
+                    array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 19),
+                )
             )
         );
     }

--- a/tests/CrEOF/Geo/String/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/String/Tests/LexerTest.php
@@ -50,12 +50,57 @@ class LexerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testReusedLexer()
+    {
+        $lexer = new Lexer();
+
+        foreach ($this->testDataSource() as $data) {
+            $index = 0;
+
+            $lexer->setInput($data[0]);
+
+            while (null !== $actual = $lexer->peek()) {
+                $this->assertEquals($data[1][$index++], $actual);
+            }
+        }
+    }
+
     /**
      * @return array[]
      */
     public function testDataSource()
     {
         return array (
+            array(
+                '15',
+                array(
+                    array('value' => 15, 'type' => Lexer::T_INTEGER, 'position' => 0),
+                )
+            ),
+            array(
+                '1E5',
+                array(
+                    array('value' => 100000, 'type' => Lexer::T_FLOAT, 'position' => 0),
+                )
+            ),
+            array(
+                '1e5',
+                array(
+                    array('value' => 100000, 'type' => Lexer::T_FLOAT, 'position' => 0),
+                )
+            ),
+            array(
+                '1.5E5',
+                array(
+                    array('value' => 150000, 'type' => Lexer::T_FLOAT, 'position' => 0),
+                )
+            ),
+            array(
+                '1E-5',
+                array(
+                    array('value' => 0.00001, 'type' => Lexer::T_FLOAT, 'position' => 0),
+                )
+            ),
             array(
                 '40° 26\' 46" N',
                 array(

--- a/tests/CrEOF/Geo/String/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/String/Tests/LexerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2014 Derek J. Lambert
+ * Copyright (C) 2016 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,18 +35,17 @@ class LexerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @param string $input
-     * @param array  $tokens
+     * @param array  $expectedTokens
      *
      * @dataProvider testDataSource
      */
-    public function testLexer($input, array $tokens)
+    public function testLexer($input, array $expectedTokens)
     {
         $lexer = new Lexer($input);
-
         $index = 0;
 
         while (null !== $actual = $lexer->peek()) {
-            $this->assertEquals($tokens[$index++], $actual);
+            $this->assertEquals($expectedTokens[$index++], $actual);
         }
     }
 
@@ -55,12 +54,14 @@ class LexerTest extends \PHPUnit_Framework_TestCase
         $lexer = new Lexer();
 
         foreach ($this->testDataSource() as $data) {
-            $index = 0;
+            $input          = $data['input'];
+            $expectedTokens = $data['expectedTokens'];
+            $index          = 0;
 
-            $lexer->setInput($data[0]);
+            $lexer->setInput($input);
 
             while (null !== $actual = $lexer->peek()) {
-                $this->assertEquals($data[1][$index++], $actual);
+                $this->assertEquals($expectedTokens[$index++], $actual);
             }
         }
     }
@@ -72,38 +73,38 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     {
         return array (
             array(
-                '15',
-                array(
+                'input'          => '15',
+                'expectedTokens' => array(
                     array('value' => 15, 'type' => Lexer::T_INTEGER, 'position' => 0),
                 )
             ),
             array(
-                '1E5',
-                array(
+                'input'          => '1E5',
+                'expectedTokens' => array(
                     array('value' => 100000, 'type' => Lexer::T_FLOAT, 'position' => 0),
                 )
             ),
             array(
-                '1e5',
-                array(
+                'input'          => '1e5',
+                'expectedTokens' => array(
                     array('value' => 100000, 'type' => Lexer::T_FLOAT, 'position' => 0),
                 )
             ),
             array(
-                '1.5E5',
-                array(
+                'input'          => '1.5E5',
+                'expectedTokens' => array(
                     array('value' => 150000, 'type' => Lexer::T_FLOAT, 'position' => 0),
                 )
             ),
             array(
-                '1E-5',
-                array(
+                'input'          => '1E-5',
+                'expectedTokens' => array(
                     array('value' => 0.00001, 'type' => Lexer::T_FLOAT, 'position' => 0),
                 )
             ),
             array(
-                '40° 26\' 46" N',
-                array(
+                'input'          => '40° 26\' 46" N',
+                'expectedTokens' => array(
                     array('value' => 40, 'type' => Lexer::T_INTEGER, 'position' => 0),
                     array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 2),
                     array('value' => 26, 'type' => Lexer::T_INTEGER, 'position' => 5),
@@ -114,8 +115,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                '40° 26\' 46" N 79° 58\' 56" W',
-                array(
+                'input'          => '40° 26\' 46" N 79° 58\' 56" W',
+                'expectedTokens' => array(
                     array('value' => 40, 'type' => Lexer::T_INTEGER, 'position' => 0),
                     array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 2),
                     array('value' => 26, 'type' => Lexer::T_INTEGER, 'position' => 5),
@@ -133,8 +134,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                '40°26\'46"N 79°58\'56"W',
-                array(
+                'input'          => '40°26\'46"N 79°58\'56"W',
+                'expectedTokens' => array(
                     array('value' => 40, 'type' => Lexer::T_INTEGER, 'position' => 0),
                     array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 2),
                     array('value' => 26, 'type' => Lexer::T_INTEGER, 'position' => 4),
@@ -152,8 +153,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                '40°26\'46"N, 79°58\'56"W',
-                array(
+                'input'          => '40°26\'46"N, 79°58\'56"W',
+                'expectedTokens' => array(
                     array('value' => 40, 'type' => Lexer::T_INTEGER, 'position' => 0),
                     array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 2),
                     array('value' => 26, 'type' => Lexer::T_INTEGER, 'position' => 4),
@@ -172,8 +173,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                '40.4738° N, 79.553° W',
-                array(
+                'input'          => '40.4738° N, 79.553° W',
+                'expectedTokens' => array(
                     array('value' => 40.4738, 'type' => Lexer::T_FLOAT, 'position' => 0),
                     array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 7),
                     array('value' => 'N', 'type' => Lexer::T_CARDINAL_LAT, 'position' => 10),
@@ -184,8 +185,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                '40.4738°, 79.553°',
-                array(
+                'input'          => '40.4738°, 79.553°',
+                'expectedTokens' => array(
                     array('value' => 40.4738, 'type' => Lexer::T_FLOAT, 'position' => 0),
                     array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 7),
                     array('value' => ',', 'type' => Lexer::T_COMMA, 'position' => 9),
@@ -194,8 +195,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 )
             ),
             array(
-                '40.4738° -79.553°',
-                array(
+                'input'          => '40.4738° -79.553°',
+                'expectedTokens' => array(
                     array('value' => 40.4738, 'type' => Lexer::T_FLOAT, 'position' => 0),
                     array('value' => '°', 'type' => Lexer::T_DEGREE, 'position' => 7),
                     array('value' => '-', 'type' => Lexer::T_MINUS, 'position' => 10),

--- a/tests/CrEOF/Geo/String/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/String/Tests/ParserTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2015 Derek J. Lambert
+ * Copyright (C) 2016 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -53,9 +53,12 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $parser = new Parser();
 
         foreach ($this->dataSourceGood() as $data) {
-            $value = $parser->parse($data[0]);
+            $input    = $data['input'];
+            $expected = $data['expected'];
 
-            $this->assertEquals($data[1], $value);
+            $value = $parser->parse($input);
+
+            $this->assertEquals($expected, $value);
         }
     }
 
@@ -81,42 +84,150 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     public function dataSourceGood()
     {
         return array(
-            array('40', 40),
-            array('-40', -40),
-            array('1E5', 100000),
-            array('1e5', 100000),
-            array('1e5°', 100000),
-            array('40°', 40),
-            array('-40°', -40),
-            array('40° N', 40),
-            array('40° S', -40),
-            array('45.24', 45.24),
-            array('45.24°', 45.24),
-            array('+45.24°', 45.24),
-            array('45.24° S', -45.24),
-            array('40° 26\' 46" N', 40.446111111111),
-            array('40:26S', -40.43333333333333),
-            array('79:56:55W', -79.948611111111),
-            array('40:26:46N', 40.446111111111),
-            array('40° N 79° W', array(40, -79)),
-            array('40 79', array(40, 79)),
-            array('40° 79°', array(40, 79)),
-            array('40, 79', array(40, 79)),
-            array('40°, 79°', array(40, 79)),
-            array('40° 26\' 46" N 79° 58\' 56" W', array(40.446111111111, -79.982222222222)),
-            array('40° 26\' N 79° 58\' W', array(40.43333333333333, -79.966666666666669)),
-            array('40.4738° N, 79.553° W', array(40.4738, -79.553)),
-            array('40.4738° S, 79.553° W', array(-40.4738, -79.553)),
-            array('40° 26.222\' N 79° 58.52\' E', array(40.437033333333, 79.975333333333)),
-            array('40°26.222\'N 79°58.52\'E', array(40.437033333333, 79.975333333333)),
-            array('40°26.222\' 79°58.52\'', array(40.437033333333, 79.975333333333)),
-            array('40.222° -79.5852°', array(40.222, -79.5852)),
-            array('40.222°, -79.5852°', array(40.222, -79.5852)),
-            array('44°58\'53.9"N 93°19\'25.8"W', array(44.981638888888888, -93.32383333333334)),
-            array('44°58\'53.9"N, 93°19\'25.8"W', array(44.981638888888888, -93.32383333333334)),
-            array('79:56:55W 40:26:46N', array(-79.948611111111, 40.446111111111)),
-            array('79:56:55 W, 40:26:46 N', array(-79.948611111111, 40.446111111111)),
-            array('79°56′55″W, 40°26′46″N', array(-79.948611111111, 40.446111111111))
+            array(
+                'input'    => '40',
+                'expected' => 40
+            ),
+            array(
+                'input'    => '-40',
+                'expected' => -40
+            ),
+            array(
+                'input'    => '1E5',
+                'expected' => 100000
+            ),
+            array(
+                'input'    => '1e5',
+                'expected' => 100000
+            ),
+            array(
+                'input'    => '1e5°',
+                'expected' => 100000
+            ),
+            array(
+                'input'    => '40°',
+                'expected' => 40
+            ),
+            array(
+                'input'    => '-40°',
+                'expected' => -40
+            ),
+            array(
+                'input'    => '40° N',
+                'expected' => 40
+            ),
+            array(
+                'input'    => '40° S',
+                'expected' => -40
+            ),
+            array(
+                'input'    => '45.24',
+                'expected' => 45.24
+            ),
+            array(
+                'input'    => '45.24°',
+                'expected' => 45.24
+            ),
+            array(
+                'input'    => '+45.24°',
+                'expected' => 45.24
+            ),
+            array(
+                'input'    => '45.24° S',
+                'expected' => -45.24
+            ),
+            array(
+                'input'    => '40° 26\' 46" N',
+                'expected' => 40.446111111111
+            ),
+            array(
+                'input'    => '40:26S',
+                'expected' => -40.43333333333333
+            ),
+            array(
+                'input'    => '79:56:55W',
+                'expected' => -79.948611111111
+            ),
+            array(
+                'input'    => '40:26:46N',
+                'expected' => 40.446111111111
+            ),
+            array(
+                'input'    => '40° N 79° W',
+                'expected' => array(40, -79)
+            ),
+            array(
+                'input'    => '40 79',
+                'expected' => array(40, 79)
+            ),
+            array(
+                'input'    => '40° 79°',
+                'expected' => array(40, 79)
+            ),
+            array(
+                'input'    => '40, 79',
+                'expected' => array(40, 79)
+            ),
+            array(
+                'input'    => '40°, 79°',
+                'expected' => array(40, 79)
+            ),
+            array(
+                'input'    => '40° 26\' 46" N 79° 58\' 56" W',
+                'expected' => array(40.446111111111, -79.982222222222)
+            ),
+            array(
+                'input'    => '40° 26\' N 79° 58\' W',
+                'expected' => array(40.43333333333333, -79.966666666666669)
+            ),
+            array(
+                'input'    => '40.4738° N, 79.553° W',
+                'expected' => array(40.4738, -79.553)
+            ),
+            array(
+                'input'    => '40.4738° S, 79.553° W',
+                'expected' => array(-40.4738, -79.553)
+            ),
+            array(
+                'input'    => '40° 26.222\' N 79° 58.52\' E',
+                'expected' => array(40.437033333333, 79.975333333333)
+            ),
+            array(
+                'input'    => '40°26.222\'N 79°58.52\'E',
+                'expected' => array(40.437033333333, 79.975333333333)
+            ),
+            array(
+                'input'    => '40°26.222\' 79°58.52\'',
+                'expected' => array(40.437033333333, 79.975333333333)
+            ),
+            array(
+                'input'    => '40.222° -79.5852°',
+                'expected' => array(40.222, -79.5852)
+            ),
+            array(
+                'input'    => '40.222°, -79.5852°',
+                'expected' => array(40.222, -79.5852)
+            ),
+            array(
+                'input'    => '44°58\'53.9"N 93°19\'25.8"W',
+                'expected' => array(44.981638888888888, -93.32383333333334)
+            ),
+            array(
+                'input'    => '44°58\'53.9"N, 93°19\'25.8"W',
+                'expected' => array(44.981638888888888, -93.32383333333334)
+            ),
+            array(
+                'input'    => '79:56:55W 40:26:46N',
+                'expected' => array(-79.948611111111, 40.446111111111)
+            ),
+            array(
+                'input'    => '79:56:55 W, 40:26:46 N',
+                'expected' => array(-79.948611111111, 40.446111111111)
+            ),
+            array(
+                'input'    => '79°56′55″W, 40°26′46″N',
+                'expected' => array(-79.948611111111, 40.446111111111)
+            )
         );
     }
 
@@ -126,30 +237,126 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     public function dataSourceBad()
     {
         return array(
-            array('-40°N 45°W', 'UnexpectedValueException', '[Syntax Error] line 0, col 5: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "N" in value "-40°N 45°W"'),
-            array('+40°N 45°W', 'UnexpectedValueException', '[Syntax Error] line 0, col 5: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "N" in value "+40°N 45°W"'),
-            array('40°N +45°W', 'UnexpectedValueException', '[Syntax Error] line 0, col 6: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "+" in value "40°N +45°W"'),
-            array('40°N -45W', 'UnexpectedValueException', '[Syntax Error] line 0, col 6: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "-" in value "40°N -45W"'),
-            array('40N -45°W', 'UnexpectedValueException', '[Syntax Error] line 0, col 4: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "-" in value "40N -45°W"'),
-            array('40N 45°W', 'UnexpectedValueException', '[Syntax Error] line 0, col 6: Error: Expected CrEOF\Geo\String\Lexer::T_CARDINAL_LON, got "°" in value "40N 45°W"'),
-            array('40°N 45°S', 'UnexpectedValueException', '[Syntax Error] line 0, col 10: Error: Expected CrEOF\Geo\String\Lexer::T_CARDINAL_LON, got "S" in value "40°N 45°S"'),
-            array('40°W 45°E', 'UnexpectedValueException', '[Syntax Error] line 0, col 10: Error: Expected CrEOF\Geo\String\Lexer::T_CARDINAL_LAT, got "E" in value "40°W 45°E"'),
-            array('40° 45', 'UnexpectedValueException', '[Syntax Error] line 0, col -1: Error: Expected CrEOF\Geo\String\Lexer::T_APOSTROPHE, got end of string. in value "40° 45"'),
-            array('40°, 45', 'UnexpectedValueException', '[Syntax Error] line 0, col -1: Error: Expected CrEOF\Geo\String\Lexer::T_DEGREE, got end of string. in value "40°, 45"'),
-            array('40N 45', 'UnexpectedValueException', '[Syntax Error] line 0, col -1: Error: Expected CrEOF\Geo\String\Lexer::T_CARDINAL_LON, got end of string. in value "40N 45"'),
-            array('40 45W', 'UnexpectedValueException', '[Syntax Error] line 0, col 5: Error: Expected end of string, got "W" in value "40 45W"'),
-            array('-40.757° 45°W', 'UnexpectedValueException', '[Syntax Error] line 0, col 14: Error: Expected end of string, got "W" in value "-40.757° 45°W"'),
-            array('40.757°N -45.567°W', 'UnexpectedValueException', '[Syntax Error] line 0, col 10: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "-" in value "40.757°N -45.567°W"'),
-            array('44°58\'53.9N 93°19\'25.8"W', 'UnexpectedValueException', '[Syntax Error] line 0, col 11: Error: Expected CrEOF\Geo\String\Lexer::T_QUOTE, got "N" in value "44°58\'53.9N 93°19\'25.8"W"'),
-            array('40:26\'', 'UnexpectedValueException', '[Syntax Error] line 0, col 5: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "\'" in value "40:26\'"'),
-            array('132.4432:', 'UnexpectedValueException', '[Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got ":" in value "132.4432:"'),
-            array('55:34:22°', 'UnexpectedValueException', '[Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "°" in value "55:34:22°"'),
-            array('55:34.22', 'UnexpectedValueException', '[Syntax Error] line 0, col 3: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER, got "34.22" in value "55:34.22"'),
-            array('55#34.22', 'UnexpectedValueException', '[Syntax Error] line 0, col 2: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "#" in value "55#34.22"'),
-            array('200N', 'RangeException', '[Range Error] Error: Degrees out of range -90 to 90 in value "200N"'),
-            array('55:200:32', 'RangeException', '[Range Error] Error: Minutes greater than 60 in value "55:200:32"'),
-            array('55:20:99', 'RangeException', '[Range Error] Error: Seconds greater than 60 in value "55:20:99"'),
-            array('55°70.99\'', 'RangeException', '[Range Error] Error: Minutes greater than 60 in value "55°70.99\'"')
+            array(
+                'input'     => '-40°N 45°W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 5: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "N" in value "-40°N 45°W"'
+            ),
+            array(
+                'input'     => '+40°N 45°W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 5: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "N" in value "+40°N 45°W"'
+            ),
+            array(
+                'input'     => '40°N +45°W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 6: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "+" in value "40°N +45°W"'
+            ),
+            array(
+                'input'     => '40°N -45W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 6: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "-" in value "40°N -45W"'
+            ),
+            array(
+                'input'     => '40N -45°W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 4: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "-" in value "40N -45°W"'
+            ),
+            array(
+                'input'     => '40N 45°W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 6: Error: Expected CrEOF\Geo\String\Lexer::T_CARDINAL_LON, got "°" in value "40N 45°W"'
+            ),
+            array(
+                'input'     => '40°N 45°S',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 10: Error: Expected CrEOF\Geo\String\Lexer::T_CARDINAL_LON, got "S" in value "40°N 45°S"'
+            ),
+            array(
+                'input'     => '40°W 45°E',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 10: Error: Expected CrEOF\Geo\String\Lexer::T_CARDINAL_LAT, got "E" in value "40°W 45°E"'
+            ),
+            array(
+                'input'     => '40° 45',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col -1: Error: Expected CrEOF\Geo\String\Lexer::T_APOSTROPHE, got end of string. in value "40° 45"'
+            ),
+            array(
+                'input'     => '40°, 45',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col -1: Error: Expected CrEOF\Geo\String\Lexer::T_DEGREE, got end of string. in value "40°, 45"'
+            ),
+            array(
+                'input'     => '40N 45',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col -1: Error: Expected CrEOF\Geo\String\Lexer::T_CARDINAL_LON, got end of string. in value "40N 45"'
+            ),
+            array(
+                'input'     => '40 45W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 5: Error: Expected end of string, got "W" in value "40 45W"'
+            ),
+            array(
+                'input'     => '-40.757° 45°W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 14: Error: Expected end of string, got "W" in value "-40.757° 45°W"'
+            ),
+            array(
+                'input'     => '40.757°N -45.567°W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 10: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "-" in value "40.757°N -45.567°W"'
+            ),
+            array(
+                'input'     => '44°58\'53.9N 93°19\'25.8"W',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 11: Error: Expected CrEOF\Geo\String\Lexer::T_QUOTE, got "N" in value "44°58\'53.9N 93°19\'25.8"W"'
+            ),
+            array(
+                'input'     => '40:26\'',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 5: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "\'" in value "40:26\'"'
+            ),
+            array(
+                'input'     => '132.4432:',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got ":" in value "132.4432:"'
+            ),
+            array(
+                'input'     => '55:34:22°',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "°" in value "55:34:22°"'
+            ),
+            array(
+                'input'     => '55:34.22',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 3: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER, got "34.22" in value "55:34.22"'
+            ),
+            array(
+                'input'     => '55#34.22',
+                'exception' => 'UnexpectedValueException',
+                'message'   => '[Syntax Error] line 0, col 2: Error: Expected CrEOF\Geo\String\Lexer::T_INTEGER or CrEOF\Geo\String\Lexer::T_FLOAT, got "#" in value "55#34.22"'
+            ),
+            array(
+                'input'     => '200N',
+                'exception' => 'RangeException',
+                'message'   => '[Range Error] Error: Degrees out of range -90 to 90 in value "200N"'
+            ),
+            array(
+                'input'     => '55:200:32',
+                'exception' => 'RangeException',
+                'message'   => '[Range Error] Error: Minutes greater than 60 in value "55:200:32"'
+            ),
+            array(
+                'input'     => '55:20:99',
+                'exception' => 'RangeException',
+                'message'   => '[Range Error] Error: Seconds greater than 60 in value "55:20:99"'
+            ),
+            array(
+                'input'     => '55°70.99\'',
+                'exception' => 'RangeException',
+                'message'   => '[Range Error] Error: Minutes greater than 60 in value "55°70.99\'"'
+            )
         );
     }
 }

--- a/tests/CrEOF/Geo/String/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/String/Tests/ParserTest.php
@@ -48,6 +48,17 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $value);
     }
 
+    public function testParserReuse()
+    {
+        $parser = new Parser();
+
+        foreach ($this->dataSourceGood() as $data) {
+            $value = $parser->parse($data[0]);
+
+            $this->assertEquals($data[1], $value);
+        }
+    }
+
     /**
      * @param string $input
      * @param string $exception
@@ -72,6 +83,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         return array(
             array('40', 40),
             array('-40', -40),
+            array('1E5', 100000),
+            array('1e5', 100000),
+            array('1e5°', 100000),
             array('40°', 40),
             array('-40°', -40),
             array('40° N', 40),

--- a/tests/TestInit.php
+++ b/tests/TestInit.php
@@ -1,9 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';
-
-error_reporting(E_ALL | E_STRICT);
-
-$loader = new \Composer\Autoload\ClassLoader();
-$loader->add('CrEOF\Geo\String\Tests', __DIR__);
-$loader->register();


### PR DESCRIPTION
## [2.1.0] - 2016-05-03
### Added
- Support for numbers in scientific notation.

### Changed
- Parser constructor no longer requires a value, enabling instance reuse.
- Lexer constructor no longer requires a value, enabling instance reuse.
- Tests now use Composer autoload.
- PHPUnit config XML now conforms to XSD.
- Documentation updated with new usage pattern.
- Move non-value comparison into if statement in Lexer::getType().
- Test case and test data cleanup.

### Removed
- TestInit no longer needed