### PR TITLE
Fix PHP 7.3.7 compatibility / Fixes an PHP 7.3.7 compatibility issue due to an invalid escape sequence.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
+  - 7.3
 
 before_script:
   - composer --prefer-source install

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "doctrine/lexer": ">=1.0"
     },
     "require-dev": {
-        "phpunit/phpunit":               ">=4.8",
+        "phpunit/phpunit":               "~5.0",
         "codeclimate/php-test-reporter": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php":            ">=5.3.3",
+        "php":            ">=7.1",
         "ext-SPL":        "*",
         "doctrine/lexer": ">=1.0"
     },

--- a/lib/CrEOF/Geo/String/Lexer.php
+++ b/lib/CrEOF/Geo/String/Lexer.php
@@ -108,7 +108,7 @@ class Lexer extends AbstractLexer
     protected function getCatchablePatterns()
     {
         return array(
-            '[nesw\'",\X]',
+            '[nesw\'",X]',
             '(?:[0-9]+)(?:[\.][0-9]+)?(?:e[+-]?[0-9]+)?'
         );
     }

--- a/lib/CrEOF/Geo/String/Lexer.php
+++ b/lib/CrEOF/Geo/String/Lexer.php
@@ -108,7 +108,7 @@ class Lexer extends AbstractLexer
     protected function getCatchablePatterns()
     {
         return array(
-            '[nesw\'",X]',
+            '[nesw\'",]',
             '(?:[0-9]+)(?:[\.][0-9]+)?(?:e[+-]?[0-9]+)?'
         );
     }


### PR DESCRIPTION
Fixes an PHP 7.3.7 compatibility issue due to an invalid escape sequence.

Example:

preg_split(): Compilation failed: escape sequence is invalid in character class at offset 10

geo-parser/vendor/doctrine/lexer/lib/Doctrine/Common/Lexer/AbstractLexer.php:259
geo-parser/vendor/doctrine/lexer/lib/Doctrine/Common/Lexer/AbstractLexer.php:96
geo-parser/lib/CrEOF/Geo/String/Parser.php:91
geo-parser/tests/CrEOF/Geo/String/Tests/ParserTest.php:78